### PR TITLE
Unexpected keys

### DIFF
--- a/hyperpyyaml/core.py
+++ b/hyperpyyaml/core.py
@@ -376,17 +376,20 @@ def _walk_tree_and_resolve(key, current_node, tree, overrides, file_path):
         elif tag_value.startswith("!include:"):
             filename = tag_value[len("!include:") :]
 
+            if file_path is not None:
+                filename = os.path.join(file_path, filename)
+
             # Update overrides with child keys
             if isinstance(current_node, dict):
                 if overrides:
                     recursive_update(overrides, current_node)
                 else:
                     overrides = dict(current_node)
-
-            if file_path is not None:
-                filename = os.path.join(file_path, filename)
-            with open(filename) as f:
-                included_yaml = resolve_references(f, overrides)
+                with open(filename) as f:
+                    included_yaml = resolve_references(f, overrides)
+            else:
+                with open(filename) as f:
+                    included_yaml = resolve_references(f)
 
             # Append resolved yaml to current node
             ruamel_yaml = ruamel.yaml.YAML()

--- a/tests/test_hyperyaml.py
+++ b/tests/test_hyperyaml.py
@@ -238,3 +238,22 @@ def test_load_hyperpyyaml(tmpdir):
         "data_folder: !PLACEHOLDER\nexamples:\n"
         "  ex1: !ref <data_folder>/ex1.wav\n"
     )
+
+    # !include with override
+    yaml_1_path = os.path.join(tmpdir, 'f1.yaml')
+    yaml_2_path = os.path.join(tmpdir, 'f2.yaml')
+
+    yaml_1_content = f'''
+    k1: v1
+    k2: !include:{yaml_2_path}
+    '''
+    yaml_2_content = f'k3: v3'
+
+    with open(yaml_2_path, 'w') as f:
+        f.write(yaml_2_content)
+
+    loaded_yaml_1 = load_hyperpyyaml(yaml_1_content, overrides='k1: new_v1')
+    print(loaded_yaml_1)
+
+    assert loaded_yaml_1.get('k1') == 'new_v1'  # 'v1' is overridden by 'new_v1
+    assert loaded_yaml_1['k2'].get('k1') is None  # no unexpected key inserted to the included yaml file

--- a/tests/test_hyperyaml.py
+++ b/tests/test_hyperyaml.py
@@ -199,7 +199,7 @@ def test_load_hyperpyyaml(tmpdir):
 
     # Import
     imported_yaml = """
-    a: !PLACEHOLDER
+    a: 10
     b: !PLACEHOLDER
     c: !ref <a> // <b>
     """
@@ -211,18 +211,25 @@ def test_load_hyperpyyaml(tmpdir):
         w.write(imported_yaml)
 
     yaml = f"""
-    a: 3
     b: !PLACEHOLDER
     import: !include:{test_yaml_file}
-        a: !ref <a>
+        a: 3
         b: !ref <b>
     d: !ref <import[c]>
     """
 
     things = load_hyperpyyaml(yaml, {"b": 3})
-    assert things["a"] == things["b"]
+    assert things["import"]["a"] == things["b"]
     assert things["import"]["c"] == 1
     assert things["d"] == things["import"]["c"]
+
+    things = load_hyperpyyaml(yaml, {"import": {"a": 6}, "b": 3})
+    assert things["import"]["a"] == 6
+    assert things["import"]["c"] == 2
+
+    things = load_hyperpyyaml(yaml, "import:\n  a: 6\nb: 3\nd: 5")
+    assert things["import"]["a"] == 6
+    assert things["d"] == 5
 
     # Dumping
     dump_dict = {


### PR DESCRIPTION
Solve the issue I reported in #9 . When interpreting the `!include` tag, there is no need to pass the `overrides` to it. In fact, I am thinking if it is necessary at all for the `_walk_tree_and_resolve` function to have the `overrides` input, since all the overrides have been handled here, before `_walk_tree_and_resolve` is called:

https://github.com/speechbrain/HyperPyYAML/blob/9a36727422df0b26cee74bc234a56754f48ebfac/hyperpyyaml/core.py#L302-L306