### PR TITLE
 redefine "!apply" to solve the issues #7 #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-tmp.py
-tmp.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+tmp.py
+tmp.yaml

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ also updates `bar`. If you want a deep copy, use the `!copy` tag.
 There are some issues (#7 #11) mentioning that `!ref` cannot refer to the return value of `!apply` function. 
 Thus we provide another `!applyref` tag to work with `!ref`, which can be used in four ways:
 
-```
+```yaml
 # 1. Pass the positional and keyword arguments at the same time. Like `!!python/object/apply:module.function` in pyyaml
 c: !applyref:sorted
     _args: 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,37 @@ Counter({'a': 4})
 Note that `!ref` makes only a shallow copy, so updating `foo`
 also updates `bar`. If you want a deep copy, use the `!copy` tag.
 
+There are some issues (#7 #11) mentioning that `!ref` cannot refer to the return value of `!apply` function. 
+Thus we provide another `!applyref` tag to work with `!ref`, which can be used in four ways:
+
+```
+# 1. Pass the positional and keyword arguments at the same time. Like `!!python/object/apply:module.function` in pyyaml
+c: !applyref:sorted
+    _args: 
+        - [3, 4, 1, 2]
+    _kwargs:
+        reverse: False
+d: !ref <c>-<c>
+
+# 2. Only pass the keyword arguments
+e: !applyref:random.randint
+    a: 1
+    b: 3
+f: !ref <e><e>
+
+# 3. Only pass the positional arguments
+g: !applyref:random.randint
+    - 1
+    - 3
+h: !ref <g><g>
+
+# 4. No arguments
+i: !applyref:random.random
+j: !ref <i><i>
+```
+
+Note that `!applyref` cannot return an object, otherwise the `RepresenterError` will be raised.
+
 ### Tuples
 
 One last minor extension to the yaml syntax we've made is to implicitly

--- a/hyperpyyaml/core.py
+++ b/hyperpyyaml/core.py
@@ -182,7 +182,6 @@ def load_hyperpyyaml(
         True,
     )  # deep=True
     hparams = yaml.load(yaml_stream, Loader=yaml.Loader)
-    print(hparams)
     # Change back to normal default:
     yaml.constructor.BaseConstructor.construct_object.__defaults__ = (
         False,

--- a/tests/test_hyperyaml.py
+++ b/tests/test_hyperyaml.py
@@ -177,6 +177,47 @@ def test_load_hyperpyyaml(tmpdir):
     assert things["c"].kwargs["thing1"]() == "a string"
     assert things["c"].specific_key() == "a string"
 
+    # Applyref tag
+    yaml = """
+    a: 1
+    b: 2
+    c: !applyref:sum [[!ref <a>, !ref <b>]]
+    d: !ref <c>-<c>
+    """
+    things = load_hyperpyyaml(yaml)
+    assert things["d"] == 0
+
+    # Applyref method
+    yaml = """
+    a: "A STRING"
+    common_kwargs:
+        thing1: !ref <a.lower>
+        thing2: 2
+    c: !applyref:hyperpyyaml.TestThing.from_keys
+        args:
+            - 1
+            - 2
+        kwargs: !ref <common_kwargs>
+    """
+    things = load_hyperpyyaml(yaml)
+    assert things["c"][:12] == "<hyperpyyaml"
+
+    yaml = """
+    a: "A STRING"
+    common_kwargs:
+        thing1: !ref <a.lower>
+        thing2: 2
+    c: !applyref:hyperpyyaml.TestThing.from_keys
+        _args: []
+        _kwargs:
+            args:
+                - 1
+                - 2
+            kwargs: !ref <common_kwargs>
+    """
+    things = load_hyperpyyaml(yaml)
+    assert things["c"][:12] == "<hyperpyyaml"
+
     # Refattr:
     yaml = """
     thing1: "A string"

--- a/tests/test_hyperyaml.py
+++ b/tests/test_hyperyaml.py
@@ -179,6 +179,7 @@ def test_load_hyperpyyaml(tmpdir):
 
     # Applyref tag
     yaml = """
+    # 1. Pass the positional and keyword arguments at the same time. Like `!!python/object/apply:module.function` in pyyaml
     c: !applyref:sorted
         _args:
             - [3, 4, 1, 2]

--- a/tests/test_hyperyaml.py
+++ b/tests/test_hyperyaml.py
@@ -179,44 +179,34 @@ def test_load_hyperpyyaml(tmpdir):
 
     # Applyref tag
     yaml = """
-    a: 1
-    b: 2
-    c: !applyref:sum [[!ref <a>, !ref <b>]]
-    d: !ref <c>-<c>
-    """
-    things = load_hyperpyyaml(yaml)
-    assert things["d"] == 0
-
-    # Applyref method
-    yaml = """
-    a: "A STRING"
-    common_kwargs:
-        thing1: !ref <a.lower>
-        thing2: 2
-    c: !applyref:hyperpyyaml.TestThing.from_keys
-        args:
-            - 1
-            - 2
-        kwargs: !ref <common_kwargs>
-    """
-    things = load_hyperpyyaml(yaml)
-    assert things["c"][:12] == "<hyperpyyaml"
-
-    yaml = """
-    a: "A STRING"
-    common_kwargs:
-        thing1: !ref <a.lower>
-        thing2: 2
-    c: !applyref:hyperpyyaml.TestThing.from_keys
-        _args: []
+    c: !applyref:sorted
+        _args:
+            - [3, 4, 1, 2]
         _kwargs:
-            args:
-                - 1
-                - 2
-            kwargs: !ref <common_kwargs>
+            reverse: False
+    d: !ref <c>-<c>
+
+    # 2. Only pass the keyword arguments
+    e: !applyref:random.randint
+        a: 1
+        b: 3
+    f: !ref <e><e>
+
+    # 3. Only pass the positional arguments
+    g: !applyref:random.randint
+        - 1
+        - 3
+    h: !ref <g><g>
+
+    # 4. No arguments
+    i: !applyref:random.random
+    j: !ref <i>
     """
     things = load_hyperpyyaml(yaml)
-    assert things["c"][:12] == "<hyperpyyaml"
+    assert things["d"] == "[1, 2, 3, 4]-[1, 2, 3, 4]"
+    assert things["f"] in [11, 22, 33]
+    assert things["h"] in [11, 22, 33]
+    assert things["j"] < 1 and things["j"] >= 0
 
     # Refattr:
     yaml = """


### PR DESCRIPTION
This is a yaml example: 
```yaml
# Get the environment variable
subtools: !apply:os.getenv ['SUBTOOLS']
model_blueprint: !ref <subtools>/pytorch/model/resnet-xvector.py
seed: 1024
__set_seed: !apply:torch.manual_seed [!ref <seed>]
```

The expected output of `load_hyperpyyaml` is

```
{'subtools': './subtools', 'model_blueprint': './subtools/pytorch/model/resnet-xvector.py', 'seed': 1024, '__set_seed': <torch._C.Generator object at 0x7f8345281f10>}
```

But I get

```
{'subtools': './subtools', 'model_blueprint': '['SUBTOOLS']/pytorch/model/resnet-xvector.py', 'seed': 1024, '__set_seed': <torch._C.Generator object at 0x7f8345281f10>}
```

I found that the problem is in `_walk_tree_and_resolve` function. When `!ref` is triggered, the `!apply` tag has not been resolved, thus the value obtained by `!ref` is the  `['SUBTOOLS']`.

A straightforward solution is to resolve the `!apply` tag in the `_walk_tree_and_resolve` function. I removed `yaml.Loader.add_multi_constructor("!apply:", _apply_function)` and added the following to `_walk_tree_and_resolve`: 

```python
elif tag_value.startswith("!apply:"):
    function = tag_value[len("!apply:") :]
    current_node = _apply_function(function, current_node)
```

The `_apply_function` is modified to:

```
def _apply_function(callable_string, node):
    callable_ = pydoc.locate(callable_string)
    if callable_ is None:
        raise ImportError("There is no such callable as %s" % callable_string)

    if not inspect.isroutine(callable_):
        raise ValueError(
            f"!apply:{callable_string} should be a callable, but is {callable_}"
        )

    try:
        args, kwargs = _get_args(node)
        out = callable_(*args, **kwargs)
        # If the return type is an object, it may not be serialized by ruamel_yaml.dump.
        return out
    except TypeError as e:
        err_msg = "Invalid argument to callable %s" % callable_string
        e.args = (err_msg, *e.args)
        raise
```

Unfortunately, this causes another problem. The return value of some functions (e.g. `torch.manual_seed`) is a class, however, it cannot be dumpted by `ruamel_yaml.dump` in `resolve_references` function. And will raise a RepresenterError:

```
ruamel.yaml.representer.RepresenterError: cannot represent an object: <torch._C.Generator object at 0x7f04a213bf10>
```

Considering that the returned class is usually not used in a yaml document, I simply convert it to a string when it cannot be dumpted:

```python
    while True:
        try:
            ruamel_yaml = ruamel.yaml.YAML()
            # Dump back to string so we can load with bells and whistles
            ruamel_yaml.dump(preview, yaml_stream)
            yaml_stream.seek(0)
            break
        except RepresenterError as e:
            error_obj = str(e).split(': ')[1]
            for key, value in preview._items():
                if str(value) == error_obj:
                    preview.update({key: str(value)})
```

The output is 

```
{'subtools': './subtools', 'model_blueprint': './subtools/pytorch/model/resnet-xvector.py', 'seed': 1024, 'set_seed': '<torch._C.Generator object at 0x7f729f279f10>'}
```