### PR TITLE
Add license to setup.py for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,17 @@ with open("README.md") as f:
 
 setuptools.setup(
     name="HyperPyYAML",
-    version="1.0.0",
+    version="1.0.1",
     description="Extensions to YAML syntax for better python interaction",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/speechbrain/HyperPyYAML",
     author="Peter Plantinga, Aku Rouhe",
     author_email="speechbrain@gmail.com",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     packages=["hyperpyyaml"],
     install_requires=["pyyaml>=5.1", "ruamel.yaml>=0.17.8"],
 )


### PR DESCRIPTION
Basically we ought to have the license on PyPI, so that anyone using pip install can automatically know if they can use our tool.