### PR TITLE
fix: adapt to ruamel.yaml new yaml_set_ctag API

### DIFF
--- a/hyperpyyaml/core.py
+++ b/hyperpyyaml/core.py
@@ -608,7 +608,9 @@ def deref(ref, full_tree, copy_mode=False):
     if attr is not None:
         node = ruamel.yaml.comments.CommentedSeq()
         node += [branch, attr]
-        node.yaml_set_tag("!apply:getattr")
+        node.yaml_set_ctag(
+            ruamel.yaml.Tag(suffix="!apply:getattr")
+        )
         return node
 
     return branch

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=["hyperpyyaml"],
-    install_requires=["pyyaml>=5.1", "ruamel.yaml>=0.17.8, <=0.17.28"],
+    install_requires=["pyyaml>=5.1", "ruamel.yaml>=0.17.28"],
 )


### PR DESCRIPTION
`ruamel.yaml` has changed its `yaml_set_tag` method to `yaml_set_ctag` which expects a `Tag` object.
With this patch, `hyperpyyaml` should be compatible with `ruamel.yaml` versions > 0.17.29.

Fixes #22 