### PR TITLE
Fix(core): Ensure Python 3.8+ compatibility by using ast.Constant

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.9, 3.13]
+                python-version: [3.9, 3.14]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -13,11 +13,11 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.9]
+                python-version: [3.9, 3.13]
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Display Python version

--- a/hyperpyyaml/core.py
+++ b/hyperpyyaml/core.py
@@ -8,6 +8,7 @@ Authors
 
 import re
 import ast
+import sys
 import yaml
 import copy
 import pydoc
@@ -715,9 +716,18 @@ def _ast_eval(node):
         ast.Pow: op.pow,
         ast.Mod: op.mod,
     }
-    if isinstance(node, ast.Num):  # <number>
-        return node.n
-    elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
+
+    # Compatibility check for Python versions
+    # In Python 3.8, ast.Num was deprecated and replaced by ast.Constant.
+    if sys.version_info >= (3, 8):
+        if isinstance(node, ast.Constant):  # <number>, <string>, <bool>, <None>
+            return node.value
+    else:
+        # For Python versions older than 3.8
+        if isinstance(node, ast.Num):  # <number>
+            return node.n
+
+    if isinstance(node, ast.BinOp):  # <left> <operator> <right>
         return ops[type(node.op)](_ast_eval(node.left), _ast_eval(node.right))
     elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
         return ops[type(node.op)](_ast_eval(node.operand))

--- a/hyperpyyaml/core.py
+++ b/hyperpyyaml/core.py
@@ -719,7 +719,7 @@ def _ast_eval(node):
 
     # Compatibility check for Python versions
     # In Python 3.8, ast.Num was deprecated and replaced by ast.Constant.
-    if sys.version_info >= (3, 8):
+    if sys.version_info >= (3, 8): 
         if isinstance(node, ast.Constant):  # <number>, <string>, <bool>, <None>
             return node.value
     else:


### PR DESCRIPTION
### Summary

When using this library on Python 3.14, I encountered this error:  

```
  File "C:\...\.venv314\Lib\site-packages\hyperpyyaml\core.py", line 718, in _ast_eval
    if isinstance(node, ast.Num):  # <number>
                        ^^^^^^^
AttributeError: module 'ast' has no attribute 'Num'
```

This PR fixes this error on Python 3.14+ and enhances the CI to ensure multi-version compatibility, including for Python 3.14. The changes should make the library more robust and future-proof.

### Problem

The `_ast_eval` function uses `ast.Num` to evaluate numeric nodes, which is incompatible with modern Python versions.

According to the [official documentation](https://docs.python.org/3/library/ast.html#node-classes), the `ast.Num` class (along with `ast.Str`, `ast.Bytes`, etc.) was **deprecated in Python 3.8** and scheduled for future removal. Starting in Python 3.8, `ast.Constant` became the unified node for all constants.

The original `AttributeError` on newer Python versions is a direct consequence of this deprecation and subsequent removal, causing `hyperpyyaml` to fail when parsing arithmetic references.

### Solution

This patch resolves the issue by implementing a version-aware check within the `_ast_eval` function in `hyperpyyaml/core.py`:

1.  **For Python versions 3.8 and newer**, the code now correctly checks for `ast.Constant` and accesses its value via the `.value` attribute.
2.  **For older Python versions (< 3.8)**, it preserves the original behavior by checking for `ast.Num` and using the `.n` attribute.

This approach ensures the library remains fully backward-compatible while supporting all modern Python interpreters.

### Additional Improvements

*   **CI Enhancement**: The GitHub Actions workflow has been updated to run tests against both Python 3.9 and 3.14, validating the fix and preventing future regressions.
