### PR TITLE
Pin ruamel.yaml<0.19.0 for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=["hyperpyyaml"],
-    install_requires=["pyyaml>=5.1", "ruamel.yaml>=0.17.28"],
+    install_requires=["pyyaml>=5.1", "ruamel.yaml>=0.17.28,<0.19.0"],
 )


### PR DESCRIPTION
## Summary
ruamel.yaml 0.19.0 was released on 2025-12-31 and introduced breaking changes to the `max_depth` API. This causes the following error when using hyperpyyaml:

```
'Loader' object has no attribute 'max_depth'
```

This PR pins `ruamel.yaml` to `<0.19.0` to prevent the incompatibility until a proper fix can be implemented.

## Context
- ruamel.yaml 0.19.0 changelog mentions: "added .max_depth to YAML() instance"
- The error occurs during model loading in SpeechBrain-based projects
- Many users are likely to hit this issue as they update dependencies

## Test plan
- Verified that pinning `ruamel.yaml<0.19.0` resolves the error
- Existing tests should continue to pass

cc @GaetanLepage @pplantinga